### PR TITLE
(PE-2800) Log SSL-related information during tests

### DIFF
--- a/acceptance/pre_suite/4_generate_certificates.rb
+++ b/acceptance/pre_suite/4_generate_certificates.rb
@@ -1,4 +1,7 @@
 step "Generate client & server SSL certificates" do
   vm = hosts.first
-  on(vm, 'cd /tmp/jvm-certificate-authority && LEIN_ROOT=true lein with-profile +acceptance generate')
+  on(vm, 'cd /tmp/jvm-certificate-authority && LEIN_ROOT=true lein with-profile +acceptance generate') do |result|
+    puts result.stderr
+    puts result.stdout
+  end
 end

--- a/acceptance/pre_suite/5_start_server.rb
+++ b/acceptance/pre_suite/5_start_server.rb
@@ -1,12 +1,18 @@
 step "Start certificate-authority test server" do
   vm = hosts.first
 
+  server_log = '/tmp/jvm-ca-server-log.out'
   command = 'cd /tmp/jvm-certificate-authority && ' +
-            'bash -c "LEIN_ROOT=true lein with-profile +acceptance server > /dev/null &"'
+            "bash -c \"LEIN_ROOT=true lein with-profile +acceptance server > #{server_log} &\""
   on(vm, command)
 
   timeout = 60
-  unless port_open_within?(vm, 8080, timeout)
+  if port_open_within?(vm, 8080, timeout)
+    on(vm, "cat #{server_log}") do |result|
+      puts result.stderr
+      puts result.stdout
+    end
+  else
     raise "Server failed to start within #{timeout} seconds"
   end
 end

--- a/acceptance/resources/config.ini
+++ b/acceptance/resources/config.ini
@@ -1,8 +1,11 @@
+[global]
+logging-config = ./acceptance/resources/logback.xml
+
 [webserver]
 host = 0.0.0.0
 port = 8080
 ssl-host = 0.0.0.0
 ssl-port = 8081
-ssl-cert = acceptance/resources/server/conf/ssl/certs/localhost.pem
-ssl-key = acceptance/resources/server/conf/ssl/private_keys/localhost.pem
-ssl-ca-cert = acceptance/resources/server/conf/ssl/certs/ca.pem
+ssl-cert = ./acceptance/resources/server/ssl/certs/localhost.pem
+ssl-key = ./acceptance/resources/server/ssl/private_keys/localhost.pem
+ssl-ca-cert = ./acceptance/resources/server/ssl/certs/ca.pem

--- a/acceptance/resources/logback.xml
+++ b/acceptance/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/acceptance/spec/puppetlabs/jvm/certificate_authority/https_request_spec.rb
+++ b/acceptance/spec/puppetlabs/jvm/certificate_authority/https_request_spec.rb
@@ -2,22 +2,49 @@ require 'rspec'
 require 'puppet'
 require 'puppet/network/http_pool'
 
-Puppet.initialize_settings ['--confdir', 'acceptance/resources/client/conf',
-                            '--certname', 'local-client']
+SETTINGS = {
+  :client_confdir => './acceptance/resources/client',
+  :client_certname => 'local-client',
+  :host => 'localhost',
+  :plaintext_port => 8080,
+  :ssl_port => 8081
+}
 
-describe 'Plaintext request localhost:8080/test/ssl/' do
+def log_ssl_information
+  puts "Test client initialized with: confdir = #{SETTINGS[:client_confdir]}"
+  puts "Test client initialized with: certname = #{SETTINGS[:client_certname]}"
+  puts
+end
+
+def log_response(response)
+  puts "Received response with headers:"
+  response.header.to_hash.each do |k, v|
+    puts "\t#{k} = #{v}"
+  end
+  puts "Received response with body:"
+  puts "\t#{response.body}"
+  puts
+end
+
+log_ssl_information
+Puppet.initialize_settings ['--confdir', SETTINGS[:client_confdir],
+                            '--certname', SETTINGS[:client_certname]]
+
+describe "Plaintext request to #{SETTINGS[:host]}:#{SETTINGS[:plaintext_port]}/test-ssl/" do
   it "should return 'Access granted'" do
-    http = Puppet::Network::HttpPool.http_instance('localhost', 8080, false)
+    http = Puppet::Network::HttpPool.http_instance(SETTINGS[:host], SETTINGS[:plaintext_port], false)
     response = http.get('/test-ssl/')
+    log_response response
     response.code.should == '200'
     response.body.should == 'Access granted'
   end
 end
 
-describe 'HTTPS request to localhost:8081/test-ssl/' do
+describe "HTTPS request to #{SETTINGS[:host]}:#{SETTINGS[:ssl_port]}/test-ssl/" do
   it "should return 'Access granted'" do
-    http = Puppet::Network::HttpPool.http_instance('localhost', 8081, true)
+    http = Puppet::Network::HttpPool.http_instance(SETTINGS[:host], SETTINGS[:ssl_port], true)
     response = http.get('/test-ssl/')
+    log_response response
     response.code.should == '200'
     response.body.should == 'Access granted'
   end

--- a/acceptance/src/clojure/puppetlabs/certificate_authority/test/puppet_agent_cert_manager.clj
+++ b/acceptance/src/clojure/puppetlabs/certificate_authority/test/puppet_agent_cert_manager.clj
@@ -43,8 +43,8 @@
     (CertificateAuthority/writeToPEM (.getPrivate agent-keypair) (io/writer (nth agent-ssl-paths 1)))
     (CertificateAuthority/writeToPEM agent-cert (io/writer (nth agent-ssl-paths 2)))
     ;; HACK - assume the location of the ca.pem file and just directly copy it into place
-    (fs/copy (io/file "acceptance/resources/server/conf/ssl/certs/ca.pem")
-             (io/file "acceptance/resources/client/conf/ssl/certs/ca.pem"))))
+    (fs/copy (io/file "./acceptance/resources/server/ssl/certs/ca.pem")
+             (io/file "./acceptance/resources/client/ssl/certs/ca.pem"))))
 
 (defn initialize!
   [master-ca confdir agent-certname]

--- a/acceptance/src/clojure/puppetlabs/certificate_authority/test/server.clj
+++ b/acceptance/src/clojure/puppetlabs/certificate_authority/test/server.clj
@@ -1,9 +1,19 @@
 (ns puppetlabs.certificate-authority.test.server
-  (:require [puppetlabs.trapperkeeper.core :as tk]))
+  (:require [puppetlabs.trapperkeeper.core :as tk]
+            [clojure.tools.logging :as log]))
+
+(defn log-ssl-information
+  [get-in-config]
+  (doseq [setting [:ssl-host :ssl-port :ssl-cert :ssl-key :ssl-ca-cert]]
+    (let [name  (name setting)
+          value (get-in-config [:webserver setting])]
+      (log/info (format "Test server initialized with: %s = %s" name value)))))
 
 (tk/defservice secure-test-server
-  [[:WebserverService add-ring-handler]]
+  [[:WebserverService add-ring-handler]
+   [:ConfigService get-in-config]]
   (init [_ context]
+        (log-ssl-information get-in-config)
         (add-ring-handler (fn [req] {:status 200 :body "Access granted"})
                           "/test-ssl")
         context)


### PR DESCRIPTION
- cert generation
- jetty config values used on server
- Ruby client certificates used
- server response headers and body

Output can be seen at: [jvm-ca acceptance tests #82](http://jenkins-enterprise.delivery.puppetlabs.net/view/trapperkeeper/job/jvm-ca%20acceptance%20tests/82/console)
