### PR TITLE
(PE-3238) Extract predicate functions from tests

### DIFF
--- a/src/clojure/puppetlabs/certificate_authority/core.clj
+++ b/src/clojure/puppetlabs/certificate_authority/core.clj
@@ -52,20 +52,6 @@
   [x]
   (instance? X509CRL x))
 
-(defn has-serial?
-  "Returns true if the serial number matches the one on the certificate."
-  [cert serial]
-  {:pre [(certificate? cert)
-         (integer? serial)]}
-  (= serial (.getSerialNumber cert)))
-
-(defn has-version?
-  "Returns true if the version matches the one on the certificate."
-  [cert version]
-  {:pre [(certificate? cert)
-         (integer? version)]}
-  (= version (.getVersion cert)))
-
 (defmulti has-subject?
   "Returns true if x has the subject identified by the x500-name string or `X500Name`.
   Default implementations are provided for `X509Certificate` and `PKCS10CertificationRequest`."
@@ -90,7 +76,7 @@
 
 (defmulti issued-by?
   "Returns true if x was issued by the x500-name string or `X500Name`.
-  Default implementations are provided for `X509Certificate`, `PKCS10CertificationRequest`, and `X509CRL`."
+  Default implementations are provided for `X509Certificate` and `X509CRL`."
   (fn [_ x500-name]
     (class x500-name)))
 
@@ -437,4 +423,3 @@
    :post [(instance? SSLContext %)]}
   (with-open [ca-cert-reader (reader ca-cert)]
     (CertificateAuthority/caCertPemToSSLContext ca-cert-reader)))
-


### PR DESCRIPTION
This commit introduces several predicate functions that simply do instanceof? checks.  These are useful in that users of this library no longer need to import the java classes, they can simply use the appropriate predicate function.

There is also 2 multi-functions in here for checking whether an object has a certain subject and a certain issuer.  These are multi-methods because the Java methods required to test this are slightly different between certificates, certificate requests, and certificate revocation lists.  The subject and issuer can be identified with either an X500Name or the string value for an X500Name.  This is useful because sometimes you are dealing with an in-memory object and other times you just have a string representation of it.

This commit is a step towards more extensive SSL testing in jvm-puppet.
These functions will make it easier to test the SSL files laid down during startup.
