### PR TITLE
Add pem->public-key function

### DIFF
--- a/src/clojure/puppetlabs/certificate_authority/core.clj
+++ b/src/clojure/puppetlabs/certificate_authority/core.clj
@@ -260,6 +260,17 @@
   (with-open [r (reader pem)]
     (CertificateAuthority/pemToPrivateKey r)))
 
+(defn pem->public-key
+  "Given the path to a PEM file (or some other object supported by clojure's `reader`),
+   decode the contents into a `PublicKey` instance. Throws an exception if multiple
+   keys are found in the PEM.
+   See `key->pem!` to write public keys."
+  [pem]
+  {:pre  [(not (nil? pem))]
+   :post [(public-key? %)]}
+  (with-open [r (reader pem)]
+    (CertificateAuthority/pemToPublicKey r)))
+
 (defn key->pem!
   "Encodes a public or private key to PEM format, and writes it to a file (or other
   stream).  Arguments:

--- a/src/java/com/puppetlabs/certificate_authority/CertificateAuthority.java
+++ b/src/java/com/puppetlabs/certificate_authority/CertificateAuthority.java
@@ -4,6 +4,7 @@ import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
@@ -412,6 +413,25 @@ public class CertificateAuthority {
         if (privateKeys.size() != 1)
             throw new IllegalArgumentException("The PEM stream must contain exactly one private key");
         return privateKeys.get(0);
+    }
+
+    /**
+     * Given a PEM reader, decode the contents into a public key.
+     * Throws an exception if multiple keys are found.
+     *
+     * @param reader Reader for a PEM-encoded stream
+     * @return The decoded public key from the stream
+     * @throws IOException
+     * @see #writeToPEM
+     */
+    public static PublicKey pemToPublicKey(Reader reader)
+        throws IOException
+    {
+        List<Object> objects = pemToObjects(reader);
+        if (objects.size() != 1)
+            throw new IllegalArgumentException("The PEM stream must contain exactly one public key");
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        return converter.getPublicKey((SubjectPublicKeyInfo) objects.get(0));
     }
 
     /**

--- a/test/puppetlabs/certificate_authority/core_test.clj
+++ b/test/puppetlabs/certificate_authority/core_test.clj
@@ -85,9 +85,24 @@
           (is (= expected-length public-length))
           (is (= expected-length private-length))))))
 
+  (testing "read public key from PEM stream"
+    (let [public-key (-> "public_keys/localhost.pem"
+                         open-ssl-file
+                         pem->public-key)]
+      (is (public-key? public-key))))
+
+  (testing "write public key to PEM stream"
+    (let [original-key (.getPublic (generate-key-pair 512))
+          parsed-key   (-> original-key
+                           (write-to-pem-stream key->pem!)
+                           pem->public-key)]
+      (is (public-key? parsed-key))
+      (is (= original-key parsed-key))))
+
   (testing "read single private key from PEM stream"
-    (let [pem         (open-ssl-file "private_keys/localhost.pem")
-          private-key (pem->private-key pem)]
+    (let [private-key (-> "private_keys/localhost.pem"
+                          open-ssl-file
+                          pem->private-key)]
       (is (private-key? private-key)))
 
     (testing "throws exception if multiple keys found"
@@ -103,9 +118,10 @@
       (is (every? private-key? private-keys))))
 
   (testing "write private key to PEM stream"
-    (let [original-key (.getPrivate (generate-key-pair))
-          pem-stream   (write-to-pem-stream original-key)
-          parsed-key   (pem->private-key pem-stream)]
+    (let [original-key (.getPrivate (generate-key-pair 512))
+          parsed-key   (-> original-key
+                           (write-to-pem-stream key->pem!)
+                           pem->private-key)]
       (is (private-key? parsed-key))
       (is (= original-key parsed-key))))
 


### PR DESCRIPTION
Our API was lacking public-key support.
This commits adds a `pem->public-key` function that returns a `java.security.PublicKey`.
