### PR TITLE
Add cn-from-x509-certificate function

### DIFF
--- a/src/clojure/puppetlabs/certificate_authority/core.clj
+++ b/src/clojure/puppetlabs/certificate_authority/core.clj
@@ -880,6 +880,14 @@
    :post [(string? %)]}
   (CertificateAuthority/getCnFromX500Principal x500-principal))
 
+(defn get-cn-from-x509-certificate
+  "Given an X509Certificate object, retrieve its common name (CN)."
+  [x509-certificate]
+  {:pre [(certificate? x509-certificate)]
+   :post [(string? %)]}
+  (-> (.getSubjectX500Principal x509-certificate)
+      get-cn-from-x500-principal))
+
 (defn get-public-key
   "Given an object which contains a public key, extract the public key
   and return it."

--- a/test/puppetlabs/certificate_authority/core_test.clj
+++ b/test/puppetlabs/certificate_authority/core_test.clj
@@ -169,6 +169,21 @@
           cn (get-cn-from-x500-principal x500-principal)]
       (is (= "myagent" cn)))))
 
+(deftest cn-from-x509-certificate-test
+  (testing "cn extracted from an X509Certificate"
+    (let [subject         (cn "foo")
+          key-pair        (generate-key-pair)
+          subj-pub        (get-public-key key-pair)
+          issuer          (cn "my ca")
+          issuer-key-pair (generate-key-pair)
+          issuer-priv     (get-private-key issuer-key-pair)
+          not-before      (generate-not-before-date)
+          not-after       (generate-not-after-date)
+          serial          42
+          certificate (sign-certificate issuer issuer-priv serial not-before
+                                        not-after subject subj-pub)]
+      (is (= "foo" (get-cn-from-x509-certificate certificate))))))
+
 (deftest certification-request-test
   (testing "create CSR"
     (let [subject (cn "subject")


### PR DESCRIPTION
This PR adds a simple wrapper around .getSubjectX500Principal and the existing get-cn-from-x500-principal functions.