### PR TITLE
Add key size parameter to cn-from-x509-certificate test

### DIFF
--- a/test/puppetlabs/certificate_authority/core_test.clj
+++ b/test/puppetlabs/certificate_authority/core_test.clj
@@ -172,10 +172,10 @@
 (deftest cn-from-x509-certificate-test
   (testing "cn extracted from an X509Certificate"
     (let [subject         (cn "foo")
-          key-pair        (generate-key-pair)
+          key-pair        (generate-key-pair 512)
           subj-pub        (get-public-key key-pair)
           issuer          (cn "my ca")
-          issuer-key-pair (generate-key-pair)
+          issuer-key-pair (generate-key-pair 512)
           issuer-priv     (get-private-key issuer-key-pair)
           not-before      (generate-not-before-date)
           not-after       (generate-not-after-date)


### PR DESCRIPTION
This PR specifies a key size of 512 to the generate-key-pair function in the cn-from-x509-certificate test, to speed it up