### PR TITLE
(MAINT) Updated changelog for 0.6.1, bumped version to 0.6.2-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1
+ * Added `get-cn-from-x509-certificate` to wrap getSubjectX500Principal and get-cn-from-x500-principal
+
 ## 0.6.0
  * Added support for revoking certificates
    * New `revoke` function for adding a certificate to a CRL

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
     :password :env/clojars_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/certificate-authority "0.6.1-SNAPSHOT"
+(defproject puppetlabs/certificate-authority "0.6.2-SNAPSHOT"
   :url "http://www.github.com/puppetlabs/jvm-certificate-authority"
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
     :password :env/clojars_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/certificate-authority "0.6.2-SNAPSHOT"
+(defproject puppetlabs/certificate-authority "0.6.1-SNAPSHOT"
   :url "http://www.github.com/puppetlabs/jvm-certificate-authority"
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
Updated changelog to reflect changes from https://github.com/puppetlabs/jvm-certificate-authority/pull/43